### PR TITLE
Switch to GitHubs preferred method of transport.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -5,15 +5,15 @@
            fetch="https://android.googlesource.com/" />
            
   <remote  name="gh"
-           fetch="git://github.com/"
+           fetch="http://github.com/"
            revision="master" />
            
   <remote  name="kang"
-           fetch="git@github.com:AOKP/"
+           fetch="https://AOKP@github.com/AOKP/"
            revision="master" />
            
   <remote  name="cm"
-           fetch="git://github.com/CyanogenMod/"
+           fetch="http://github.com/CyanogenMod/"
            revision="ics" />
 
   <default revision="refs/tags/android-4.0.3_r1"


### PR DESCRIPTION
  -Should speed things up be optimized and not have the random crap-outs/errors.
  -Details here https://github.com/blog/642-smart-http-support

Also, are we even using this remote anymore? Doesn't look like it to me, but maybe I'm missing something.

  <remote  name="kang"
           fetch="git@github.com:AOKP/"
           revision="master" />

Might be worth removing for cleanliness sake.
